### PR TITLE
Improve defensive detection and visual indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # skeetresolver
+
+Enhanced resolver script for the gamesense/skeet API.
+
+Features
+--------
+- Animated gradient watermark
+- Colourful indicators above enemies
+- Improved defensive anti-aim detection
+
+## Recommended Settings
+- Resolver: **Enable**
+- Resolver Mode: **Balanced**
+- Adaptive step: **On** with *Step size* **15°**
+- Jitter side-guess: **On** with *Side guess angle* **58°**
+- Brute spread: **30°**
+- Aggressive spread: **25°**
+- Watermark enabled with speed **5x**
+- Indicator colour: `80 150 255 255`
+
+These values generally provide solid results but may require tuning for specific servers.

--- a/r3s0lv3r.lua
+++ b/r3s0lv3r.lua
@@ -14,10 +14,15 @@ local cb_head= UI.new_checkbox("RAGE","Other","Head trace check")
 local cb_body= UI.new_checkbox("RAGE","Other","Body trace fallback")
 local cb_lag = UI.new_checkbox("RAGE","Other","Lag‑peek filter")
 local cb_step= UI.new_checkbox("RAGE","Other","Adaptive step")
-local cb_side= UI.new_checkbox("RAGE","Other","Jitter side‑guess (±58°)")
+local sl_step= UI.new_slider("RAGE","Other","Step size",5,30,15,"°")
+local cb_side= UI.new_checkbox("RAGE","Other","Jitter side‑guess")
+local sl_side= UI.new_slider("RAGE","Other","Side guess angle",30,90,58,"°")
+local sl_brute= UI.new_slider("RAGE","Other","Brute spread",10,60,30,"°")
+local sl_aggr = UI.new_slider("RAGE","Other","Aggressive spread",10,40,25,"°")
 UI.new_label("RAGE","Other","— Visuals —")
 local cp_col = UI.new_color_picker("RAGE","Other","Indicator colour",80,150,255,255)
 local cb_wm  = UI.new_checkbox("RAGE","Other","Watermark")
+local sl_wm_speed = UI.new_slider("RAGE","Other","Watermark speed",1,10,5,"x")
 UI.new_label("RAGE","Other","— Audio —")
 local cb_song= UI.new_checkbox("RAGE","Other","Play Новосибирская игра ♫")
 ------------------------------------------------------------------------
@@ -44,6 +49,13 @@ local function air(e)   return M.b.band(flags(e),1)==0 end
 local function vel_low(e) return (E.get_prop(e,"m_flVelocityModifier") or 1)<0.9 end
 local function lby_delta(e) local l=E.get_prop(e,"m_flLowerBodyYawTarget") or 0; return M.m.abs(yaw(e)-l) end
 local function sign(v)  return v<0 and "left" or "right" end
+local function def_detect(e)
+  if air(e) then return false end
+  local low = vel_low(e)
+  local pb  = pitch(e)
+  local ld  = lby_delta(e)
+  return (low and (pb<-15 or ld>45)) or M.m.abs(roll(e))>10
+end
 local function lagpeek(e)
   if not UI.get(cb_lag) then return false end
   local st=E.get_prop(e,"m_flSimulationTime") or 0; local d=st-(S.sim[e] or st); S.sim[e]=st
@@ -56,7 +68,27 @@ local function trace_ok(e,off,hb)
   P.set(e,"Override yaw offset",off); local _,tgt=C.trace_bullet(lp,ex,ey,ez,hx,hy,hz,false)
   return tgt==e
 end
-local function mesh(b,s,n) local t={b}; for i=1,n do t[#t+1]=b+s*i; t[#t+1]=b-s*i end return t end
+local function mesh(b,s,n)
+  local t={b}
+  for i=1,n do t[#t+1]=b+s*i; t[#t+1]=b-s*i end
+  return t
+end
+local function hsv(h,s,v)
+  local i = M.m.floor(h*6)
+  local f = h*6 - i
+  local p = v*(1-s)
+  local q = v*(1-f*s)
+  local t = v*(1-(1-f)*s)
+  i = i % 6
+  local r,g,b
+  if i==0 then r,g,b=v,t,p
+  elseif i==1 then r,g,b=q,v,p
+  elseif i==2 then r,g,b=p,v,t
+  elseif i==3 then r,g,b=p,q,v
+  elseif i==4 then r,g,b=t,p,v
+  else r,g,b=v,p,q end
+  return M.m.floor(r*255),M.m.floor(g*255),M.m.floor(b*255)
+end
 ------------------------------------------------------------------------
 -- ◇ Classification ---------------------------------------------------
 local function classify(e)
@@ -65,23 +97,40 @@ local function classify(e)
   if M.m.abs(roll(e))>15          then return "Roll" end
   if d>85                         then return "Flick" end
   if d>=30                        then return "Jitter" end
-  if pitch(e)<-20 or vel_low(e) or lby_delta(e)>35 then return "Defensive" end
+  if def_detect(e)                then return "Defensive" end
   return "Static"
 end
 ------------------------------------------------------------------------
 -- ◇ Offset decision --------------------------------------------------
 local function choose(e,mode)
   if lagpeek(e) or air(e) then return 0 end
-  if UI.get(cb_side) and S.cls[e]=="Jitter" then local g=(S.yaw[e] or 0)>=0 and 58 or -58; if trace_ok(e,g,0) then return g end end
+  if UI.get(cb_side) and S.cls[e]=="Jitter" then
+    local ang = UI.get(sl_side)
+    local g=(S.yaw[e] or 0)>=0 and ang or -ang
+    if trace_ok(e,g,0) then return g end
+  end
   local base=S.last[e] or 0
-  if mode=="Brute" then S.idx[e]=(S.idx[e] or 0)%8+1; return mesh(base,30,4)[S.idx[e]] end
+  if S.cls[e]=="Defensive" then
+    for _,o in ipairs(mesh(base,20,2)) do
+      if trace_ok(e,o,0) then return o end
+    end
+  end
+  if mode=="Brute" then
+    local spread = UI.get(sl_brute)
+    S.idx[e]=(S.idx[e] or 0)%8+1
+    return mesh(base,spread,4)[S.idx[e]]
+  end
   if mode=="Learning" then return S.last[e] end
-  local set=mesh(base,25,5)
+  local set=mesh(base,UI.get(sl_aggr),5)
   if mode=="Aggressive" or mode=="Novosibirsk" then
     for _,o in ipairs(set) do if trace_ok(e,o,0) then return o end end
     if UI.get(cb_body) then for _,o in ipairs(set) do if trace_ok(e,o,3) then return o end end end
   end
-  if UI.get(cb_step) and (S.miss[e] or 0)>0 then local step=(S.last[e] or 0)>=0 and 15 or -15; return M.m.max(-180,M.m.min(180,(S.last[e] or 0)+step)) end
+  if UI.get(cb_step) and (S.miss[e] or 0)>0 then
+    local size = UI.get(sl_step)
+    local step = (S.last[e] or 0)>=0 and size or -size
+    return M.m.max(-180,M.m.min(180,(S.last[e] or 0)+step))
+  end
   return base
 end
 ------------------------------------------------------------------------
@@ -111,9 +160,14 @@ local function watermark()
   if not UI.get(cb_wm) then return end
   local txt=(UI.get(cb_mode)=="Novosibirsk" and "novosibirsk" or "t.me/aesterial")
   local sw,sh=client.screen_size(); local y=sh-18; local x=(sw/2)-renderer.measure_text("b",txt)/2
-  for i=1,#txt do local ch=txt:sub(i,i); local t=(i-1)/(#txt-1)*2; local w=t<=1 and t or 2-t
-    local r,g,b = (txt:sub(1,6)=="НОВОС" and 255 or 40)+(215*w*(txt:sub(1,6)~="НОВОС" and 1 or -1)), 40+(215*w), (txt:sub(1,6)=="НОВОС" and 40 or 255)
-    R.text(x,y-2,r,g,b,255,"b",0,ch); x=x+renderer.measure_text("b",ch) end
+  local speed = UI.get(sl_wm_speed)*0.1
+  for i=1,#txt do
+    local ch=txt:sub(i,i)
+    local hue=(G.curtime()*speed + i/#txt)%1
+    local r,g,b=hsv(hue,1,1)
+    R.text(x,y-2,r,g,b,255,"b",0,ch)
+    x=x+renderer.measure_text("b",ch)
+  end
 end
 ------------------------------------------------------------------------
 local function hud()
@@ -123,6 +177,18 @@ local function hud()
   local focus = C.current_threat() or me
   if focus and E.is_enemy(focus) then
     R.indicator(r,g,b,a,string.format("$ %s | %s (%s) $",E.get_player_name(focus),S.cls[focus] or "--",sign(yaw(focus))))
+  end
+  for _,e in ipairs(E.get_players(true)) do
+    if not E.is_enemy(e) then goto cont end
+    local x1,y1,x2,y2,alpha = E.get_bounding_box(e)
+    if alpha == 0 then goto cont end
+    local cls = S.cls[e]
+    if not cls then goto cont end
+    local cx = (x1+x2)/2
+    local hue = (G.curtime()*0.4 + e*0.07)%1
+    local rr,gg,bb = hsv(hue,1,1)
+    R.text(cx,y1-12,rr,gg,bb,alpha,'c',0,cls)
+    ::cont::
   end
   -- simple watermark
   watermark()


### PR DESCRIPTION
## Summary
- rewrite defensive anti-aim detection
- pick offsets for defensive enemies
- draw colourful classification text above players
- document new features in README

## Testing
- `luac -p r3s0lv3r.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686568b0552c832a9fb247d2aba053c5